### PR TITLE
add stop/delete experiment endpoint

### DIFF
--- a/examples/taxis/tutorial.ipynb
+++ b/examples/taxis/tutorial.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": 226,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,14 +57,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": 227,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/28/qxhr4yq11msffjc0l_5279bc0000gn/T/ipykernel_61706/1265254364.py:3: UserWarning: pandas only supports SQLAlchemy connectable (engine/connection) or database string URI or sqlite3 DBAPI2 connection. Other DBAPI2 objects are not tested. Please consider using SQLAlchemy.\n",
+      "/var/folders/28/qxhr4yq11msffjc0l_5279bc0000gn/T/ipykernel_17696/1265254364.py:3: UserWarning: pandas only supports SQLAlchemy connectable (engine/connection) or database string URI or sqlite3 DBAPI2 connection. Other DBAPI2 objects are not tested. Please consider using SQLAlchemy.\n",
       "  pd.read_sql('SELECT * FROM taxi_departures ORDER BY received_at DESC LIMIT 10', conn)\n"
      ]
     },
@@ -105,7 +105,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 196,
+     "execution_count": 227,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": 228,
    "metadata": {
     "scrolled": true
    },
@@ -134,7 +134,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/28/qxhr4yq11msffjc0l_5279bc0000gn/T/ipykernel_61706/3064716863.py:23: UserWarning: pandas only supports SQLAlchemy connectable (engine/connection) or database string URI or sqlite3 DBAPI2 connection. Other DBAPI2 objects are not tested. Please consider using SQLAlchemy.\n",
+      "/var/folders/28/qxhr4yq11msffjc0l_5279bc0000gn/T/ipykernel_17696/3064716863.py:23: UserWarning: pandas only supports SQLAlchemy connectable (engine/connection) or database string URI or sqlite3 DBAPI2 connection. Other DBAPI2 objects are not tested. Please consider using SQLAlchemy.\n",
       "  pd.read_sql('SELECT * FROM taxi_arrivals ORDER BY received_at DESC LIMIT 10', conn)\n"
      ]
     },
@@ -175,7 +175,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 197,
+     "execution_count": 228,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": 229,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": 230,
    "metadata": {},
    "outputs": [
     {
@@ -274,7 +274,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 199,
+     "execution_count": 230,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -308,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": 231,
    "metadata": {},
    "outputs": [
     {
@@ -317,7 +317,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 200,
+     "execution_count": 231,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -363,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": 232,
    "metadata": {},
    "outputs": [
     {
@@ -372,7 +372,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 201,
+     "execution_count": 232,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -420,16 +420,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": 233,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "b'{\"name\":\"Taxi trips lin reg experiment\",\"model_state\":\"gASVzgMAAAAAAACMFnJpdmVyLmNvbXBvc2UucGlwZWxpbmWUjAhQaXBlbGluZZSTlCmBlH2UKIwFc3RlcHOUjAtjb2xsZWN0aW9uc5SMC09yZGVyZWREaWN0lJOUKVKUKIwOU3RhbmRhcmRTY2FsZXKUjBlyaXZlci5wcmVwcm9jZXNzaW5nLnNjYWxllIwOU3RhbmRhcmRTY2FsZXKUk5QpgZR9lCiMCHdpdGhfc3RklIiMBmNvdW50c5RoBowHQ291bnRlcpSTlH2UhZRSlIwFbWVhbnOUaAaMC2RlZmF1bHRkaWN0lJOUjApkaWxsLl9kaWxslIwKX2xvYWRfdHlwZZSTlIwFZmxvYXSUhZRSlIWUUpSMBHZhcnOUaBloH4WUUpR1YowQTGluZWFyUmVncmVzc2lvbpSMGnJpdmVyLmxpbmVhcl9tb2RlbC5saW5fcmVnlIwQTGluZWFyUmVncmVzc2lvbpSTlCmBlH2UKIwJb3B0aW1pemVylIwPcml2ZXIub3B0aW0uc2dklIwDU0dElJOUKYGUfZQojAJscpSMFnJpdmVyLm9wdGltLnNjaGVkdWxlcnOUjAhDb25zdGFudJSTlCmBlH2UjA1sZWFybmluZ19yYXRllEc/hHrhR64Ue3NijAxuX2l0ZXJhdGlvbnOUSwB1YowEbG9zc5SMEnJpdmVyLm9wdGltLmxvc3Nlc5SMB1NxdWFyZWSUk5QpgZSMAmwylEcAAAAAAAAAAIwCbDGURwAAAAAAAAAAjA5pbnRlcmNlcHRfaW5pdJRHAAAAAAAAAACMCWludGVyY2VwdJRHAAAAAAAAAACMDGludGVyY2VwdF9scpRoNCmBlH2UaDdHP4R64UeuFHtzYowNY2xpcF9ncmFkaWVudJRHQm0alKIAAACMC2luaXRpYWxpemVylIwYcml2ZXIub3B0aW0uaW5pdGlhbGl6ZXJzlIwFWmVyb3OUk5QpgZR9lIwFdmFsdWWURwAAAAAAAAAAc2KMCF93ZWlnaHRzlIwWcml2ZXIudXRpbHMudmVjdG9yZGljdJSMGV9fcHl4X3VucGlja2xlX1ZlY3RvckRpY3SUk5RoTowKVmVjdG9yRGljdJSTlEp3N2EBToeUUpQofZROiU6JiXSUYowHX3lfbmFtZZROdWJ1jAVsZWFybpRoHIwKTWV0aG9kVHlwZZSFlFKUaACMElBpcGVsaW5lLmxlYXJuX29uZZSTlGgDhpRSlIwHcHJlZGljdJRoW2gAjBRQaXBlbGluZS5wcmVkaWN0X29uZZSTlGgDhpRSlHViLg==\",\"sync_seconds\":20,\"target_id\":2,\"runner_id\":1,\"id\":2,\"n_samples_trained_on\":0,\"feature_set_id\":2,\"model_id\":2,\"sink_id\":1}'"
+       "b'{\"id\":2,\"n_samples_trained_on\":0,\"feature_set_id\":2,\"model_id\":2,\"sink_id\":1,\"name\":\"Taxi trips lin reg experiment\",\"model_state\":\"gASVzgMAAAAAAACMFnJpdmVyLmNvbXBvc2UucGlwZWxpbmWUjAhQaXBlbGluZZSTlCmBlH2UKIwFc3RlcHOUjAtjb2xsZWN0aW9uc5SMC09yZGVyZWREaWN0lJOUKVKUKIwOU3RhbmRhcmRTY2FsZXKUjBlyaXZlci5wcmVwcm9jZXNzaW5nLnNjYWxllIwOU3RhbmRhcmRTY2FsZXKUk5QpgZR9lCiMCHdpdGhfc3RklIiMBmNvdW50c5RoBowHQ291bnRlcpSTlH2UhZRSlIwFbWVhbnOUaAaMC2RlZmF1bHRkaWN0lJOUjApkaWxsLl9kaWxslIwKX2xvYWRfdHlwZZSTlIwFZmxvYXSUhZRSlIWUUpSMBHZhcnOUaBloH4WUUpR1YowQTGluZWFyUmVncmVzc2lvbpSMGnJpdmVyLmxpbmVhcl9tb2RlbC5saW5fcmVnlIwQTGluZWFyUmVncmVzc2lvbpSTlCmBlH2UKIwJb3B0aW1pemVylIwPcml2ZXIub3B0aW0uc2dklIwDU0dElJOUKYGUfZQojAJscpSMFnJpdmVyLm9wdGltLnNjaGVkdWxlcnOUjAhDb25zdGFudJSTlCmBlH2UjA1sZWFybmluZ19yYXRllEc/hHrhR64Ue3NijAxuX2l0ZXJhdGlvbnOUSwB1YowEbG9zc5SMEnJpdmVyLm9wdGltLmxvc3Nlc5SMB1NxdWFyZWSUk5QpgZSMAmwylEcAAAAAAAAAAIwCbDGURwAAAAAAAAAAjA5pbnRlcmNlcHRfaW5pdJRHAAAAAAAAAACMCWludGVyY2VwdJRHAAAAAAAAAACMDGludGVyY2VwdF9scpRoNCmBlH2UaDdHP4R64UeuFHtzYowNY2xpcF9ncmFkaWVudJRHQm0alKIAAACMC2luaXRpYWxpemVylIwYcml2ZXIub3B0aW0uaW5pdGlhbGl6ZXJzlIwFWmVyb3OUk5QpgZR9lIwFdmFsdWWURwAAAAAAAAAAc2KMCF93ZWlnaHRzlIwWcml2ZXIudXRpbHMudmVjdG9yZGljdJSMGV9fcHl4X3VucGlja2xlX1ZlY3RvckRpY3SUk5RoTowKVmVjdG9yRGljdJSTlEp3N2EBToeUUpQofZROiU6JiXSUYowHX3lfbmFtZZROdWJ1jAVsZWFybpRoHIwKTWV0aG9kVHlwZZSFlFKUaACMElBpcGVsaW5lLmxlYXJuX29uZZSTlGgDhpRSlIwHcHJlZGljdJRoW2gAjBRQaXBlbGluZS5wcmVkaWN0X29uZZSTlGgDhpRSlHViLg==\",\"sync_seconds\":20,\"target_id\":2,\"runner_id\":1,\"task_ids\":\"e5c1f704-999a-49f2-a909-50c36f699122,456ed142-8ed9-4dac-aeb9-5f34d14d57cf,9fb7a2b5-bd7e-4df4-8a55-b3b2338b3329\"}'"
       ]
      },
-     "execution_count": 202,
+     "execution_count": 233,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -465,23 +465,108 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": 234,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "b'Internal Server Error'"
+       "b'{\"now\":\"2023-02-14T21:01:42.422314\",\"training_progress\":0.0,\"mse\":520022.3333333333,\"mae\":529.5079365079365}'"
       ]
      },
-     "execution_count": 169,
+     "execution_count": 234,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "monitor = requests.get(\n",
-    "    \"http://localhost:8000/api/experiments/4/monitor\",\n",
+    "    \"http://localhost:8000/api/experiments/2/monitor\",\n",
+    ")\n",
+    "\n",
+    "monitor.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 235,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'{\"id\":2,\"model_state\":null,\"n_samples_trained_on\":0,\"sync_seconds\":20,\"task_ids\":\"e5c1f704-999a-49f2-a909-50c36f699122,456ed142-8ed9-4dac-aeb9-5f34d14d57cf,9fb7a2b5-bd7e-4df4-8a55-b3b2338b3329\",\"name\":\"Taxi trips lin reg experiment\",\"feature_set_id\":2,\"target_id\":2,\"model_id\":2,\"runner_id\":1,\"sink_id\":1}'"
+      ]
+     },
+     "execution_count": 235,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "monitor = requests.get(\n",
+    "    \"http://localhost:8000/api/experiments/2\",\n",
+    ")\n",
+    "\n",
+    "monitor.content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stop/Delete an experiment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can stop running experiment or delete it completely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 236,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Response [200]>"
+      ]
+     },
+     "execution_count": 236,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "monitor = requests.get(\n",
+    "    \"http://localhost:8000/api/experiments/2/stop\",\n",
+    ")\n",
+    "monitor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 237,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'{\"ok\":true}'"
+      ]
+     },
+     "execution_count": 237,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "monitor = requests.delete(\n",
+    "    \"http://localhost:8000/api/experiments/2\",\n",
     ")\n",
     "\n",
     "monitor.content"


### PR DESCRIPTION
- currently there are 3 celery tasks that run inference, training and metrics. these are unbounded tasks which means queue is blocked if we reach max number of workers (currently set at 6 in docker-compose), that's 2 experiments.
- add a small functionality to cancel running tasks for given experiment to be able to launch new experiments
- track list of celery task ids for each experiment

feature pr: add additional way of running training and inference jobs that are infinite in its nature