### PR TITLE
Update/fix a few lines in taxi example readme

### DIFF
--- a/examples/taxis/README.md
+++ b/examples/taxis/README.md
@@ -11,7 +11,7 @@ First of all you need a running instance of Beaver. For instance, you can to the
 Beaver is being run in a Docker container. You'll interact with it from your host machine. You need to install some Python dependencies to do that. We'll install them in a virtual environment 🐍
 
 ```sh
-venv .venv
+venv .venv # may be `virtualenv .venv` depending on your environment
 source .venv/bin/activate
 pip install -r requirements.txt
 
@@ -31,7 +31,7 @@ After notebook has started, make sure that selected kernel is `venv`
 Now we can simulate traffic. The order is the same as what happened in production. This is because we know the departure and arrival times of each taxi trip, and can thus reproduce the exact same timeline. We'll apply a x15 speed-up to make things more exciting ⚡️
 
 ```sh
-python simulate.py --speed 15
+python simulate.py 15
 ```
 
 


### PR DESCRIPTION
1) On my mac (python 3.8.2, etc.), the command was `virtualenv .venv`.  Googling around, it seems like `virtualenv` is more common... is `venv` an alias you defined on your machine or is that the right command name for some platforms?

2) Looks like `speed` is defined as a positional not named argument in the simulation script, this was a necessary fix to make the script run

Thanks!